### PR TITLE
test: Oracle endblocker validator reward test

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -44,7 +44,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 
 		// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
 		for _, ballotDenom := range ballotDenomSlice {
-			if sdk.NewDec(ballotDenom.Ballot.Power() / 100).LTE(k.VoteThreshold(ctx)) {
+			if sdk.NewDecWithPrec(ballotDenom.Ballot.Power(), 2).LTE(k.VoteThreshold(ctx)) {
 				continue
 			}
 

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	displayDenom string = appparams.DisplayDenom
-	bondDenom    string = appparams.BondDenom
+	displayDenom     string = appparams.DisplayDenom
+	bondDenom        string = appparams.BondDenom
+	preVoteBlockDiff int64  = 2
+	voteBlockDiff    int64  = 3
 )
 
 type IntegrationTestSuite struct {
@@ -137,7 +139,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -149,7 +151,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	}
 
 	// update prevotes' block
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + preVoteBlockDiff)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -157,7 +159,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
@@ -168,7 +170,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	}
 
 	// update prevotes' block
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + preVoteBlockDiff)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -196,7 +198,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -269,7 +271,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -278,7 +280,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 31), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr2).Rewards[0])
 
 	// update prevotes' block
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + preVoteBlockDiff)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -307,7 +309,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -316,7 +318,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 60), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr2).Rewards[0])
 
 	// update prevotes' block
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + preVoteBlockDiff)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -329,7 +331,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + voteBlockDiff)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -45,7 +45,7 @@ func (s *IntegrationTestSuite) SetupTest() {
 	app := ojoapp.Setup(s.T(), false, 1)
 	ctx := app.BaseApp.NewContext(isCheckTx, tmproto.Header{
 		ChainID: fmt.Sprintf("test-chain-%s", tmrand.Str(4)),
-		Height:  9,
+		Height:  6,
 	})
 
 	oracle.InitGenesis(ctx, app.OracleKeeper, *types.DefaultGenesisState())
@@ -58,6 +58,10 @@ func (s *IntegrationTestSuite) SetupTest() {
 	require.NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr1, initCoins))
 	require.NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, initCoins))
 	require.NoError(app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr2, initCoins))
+
+	// mint and send coins to oracle module to fill up reward pool
+	require.NoError(app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, initCoins))
+	require.NoError(app.BankKeeper.SendCoinsFromModuleToModule(ctx, minttypes.ModuleName, types.ModuleName, initCoins))
 
 	sh.CreateValidatorWithValPower(valAddr1, valPubKey1, 70, true)
 	sh.CreateValidatorWithValPower(valAddr2, valPubKey2, 30, true)
@@ -133,7 +137,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(app.OracleKeeper.VotePeriod(ctx)))
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -145,6 +149,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	}
 
 	// update prevotes' block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -152,7 +157,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(app.OracleKeeper.VotePeriod(ctx)))
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
@@ -163,6 +168,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	}
 
 	// update prevotes' block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
 	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
 
@@ -190,7 +196,7 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(app.OracleKeeper.VotePeriod(ctx)))
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	oracle.EndBlocker(ctx, app.OracleKeeper)
@@ -201,6 +207,135 @@ func (s *IntegrationTestSuite) TestEnblockerVoteThreshold() {
 	rate, err = app.OracleKeeper.GetExchangeRate(ctx, "atom")
 	s.Require().ErrorIs(err, sdkerrors.Wrap(types.ErrUnknownDenom, "atom"))
 	s.Require().Equal(sdk.ZeroDec(), rate)
+}
+
+func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
+	app, ctx := s.app, s.ctx
+
+	app.OracleKeeper.SetMandatoryList(ctx, types.DenomList{
+		{
+			BaseDenom:   bondDenom,
+			SymbolDenom: "ojo",
+			Exponent:    uint32(6),
+		},
+		{
+			BaseDenom:   "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+			SymbolDenom: "atom",
+			Exponent:    uint32(6),
+		},
+	})
+
+	var (
+		val1Tuples   types.ExchangeRateTuples
+		val2Tuples   types.ExchangeRateTuples
+		val1PreVotes types.AggregateExchangeRatePrevote
+		val2PreVotes types.AggregateExchangeRatePrevote
+		val1Votes    types.AggregateExchangeRateVote
+		val2Votes    types.AggregateExchangeRateVote
+	)
+	for _, denom := range app.OracleKeeper.AcceptList(ctx) {
+		val1Tuples = append(val1Tuples, types.ExchangeRateTuple{
+			Denom:        denom.SymbolDenom,
+			ExchangeRate: sdk.MustNewDecFromStr("1.0"),
+		})
+		val2Tuples = append(val2Tuples, types.ExchangeRateTuple{
+			Denom:        denom.SymbolDenom,
+			ExchangeRate: sdk.MustNewDecFromStr("0.5"),
+		})
+	}
+
+	val1PreVotes = types.AggregateExchangeRatePrevote{
+		Hash:        "hash1",
+		Voter:       valAddr1.String(),
+		SubmitBlock: uint64(ctx.BlockHeight()),
+	}
+	val2PreVotes = types.AggregateExchangeRatePrevote{
+		Hash:        "hash2",
+		Voter:       valAddr2.String(),
+		SubmitBlock: uint64(ctx.BlockHeight()),
+	}
+
+	val1Votes = types.AggregateExchangeRateVote{
+		ExchangeRateTuples: val1Tuples,
+		Voter:              valAddr1.String(),
+	}
+	val2Votes = types.AggregateExchangeRateVote{
+		ExchangeRateTuples: val2Tuples,
+		Voter:              valAddr2.String(),
+	}
+
+	// validator 1 and 2 vote on both currencies so both have 0 misses
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr1, val1PreVotes)
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 31), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr1).Rewards[0])
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 31), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr2).Rewards[0])
+
+	// update prevotes' block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
+	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
+
+	// validator 1 votes on both currencies to end up with 0 misses
+	// validator 2 votes on 1 currency to end up with 1 misses
+	val1Tuples = types.ExchangeRateTuples{
+		types.ExchangeRateTuple{
+			Denom:        "ojo",
+			ExchangeRate: sdk.MustNewDecFromStr("1.0"),
+		},
+		types.ExchangeRateTuple{
+			Denom:        "atom",
+			ExchangeRate: sdk.MustNewDecFromStr("0.5"),
+		},
+	}
+	val2Tuples = types.ExchangeRateTuples{
+		types.ExchangeRateTuple{
+			Denom:        "ojo",
+			ExchangeRate: sdk.MustNewDecFromStr("0.5"),
+		},
+	}
+	val1Votes.ExchangeRateTuples = val1Tuples
+	val2Votes.ExchangeRateTuples = val2Tuples
+
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr1, val1PreVotes)
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 62), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr1).Rewards[0])
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 60), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr2).Rewards[0])
+
+	// update prevotes' block
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 2)
+	val1PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
+	val2PreVotes.SubmitBlock = uint64(ctx.BlockHeight())
+
+	// validator 1 and 2 miss both currencies so validator 1 has 2 misses and
+	// validator 2 has 3 misses
+	val1Votes.ExchangeRateTuples = types.ExchangeRateTuples{}
+	val2Votes.ExchangeRateTuples = types.ExchangeRateTuples{}
+
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr1, val1PreVotes)
+	app.OracleKeeper.SetAggregateExchangeRatePrevote(ctx, valAddr2, val2PreVotes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 3)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
+	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
+	oracle.EndBlocker(ctx, app.OracleKeeper)
+
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 93), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr1).Rewards[0])
+	s.Require().Equal(sdk.NewInt64DecCoin("uojo", 89), app.DistrKeeper.GetValidatorCurrentRewards(ctx, valAddr2).Rewards[0])
 }
 
 func TestOracleTestSuite(t *testing.T) {

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -215,7 +215,7 @@ func (s *IntegrationTestSuite) TestEnblockerValidatorRewards() {
 	app.OracleKeeper.SetMandatoryList(ctx, types.DenomList{
 		{
 			BaseDenom:   bondDenom,
-			SymbolDenom: "ojo",
+			SymbolDenom: appparams.DisplayDenom,
 			Exponent:    uint32(6),
 		},
 		{

--- a/x/oracle/keeper/reward.go
+++ b/x/oracle/keeper/reward.go
@@ -79,7 +79,7 @@ func (k Keeper) RewardBallotWinners(
 
 		rewardFactor := reward.CalculateRewardFactor(
 			sdk.NewDec(int64(k.GetMissCounter(ctx, winner.Recipient))),
-			sdk.NewDec(int64(len(voteTargets))),
+			sdk.NewDec(int64(len(voteTargets)*(int(k.SlashWindow(ctx)/k.VotePeriod(ctx))))),
 			sdk.NewDec(smallestMissCount),
 		)
 

--- a/x/oracle/keeper/reward_test.go
+++ b/x/oracle/keeper/reward_test.go
@@ -44,9 +44,12 @@ func (s *IntegrationTestSuite) TestRewardBallotWinners() {
 	for i := 1; i <= 3; i++ {
 		voteTargets = append(voteTargets, fmt.Sprintf("%s%d", types.OjoSymbol, i))
 	}
+	maximumMissCounts := uint64(len(voteTargets)) * (app.OracleKeeper.SlashWindow(ctx) / app.OracleKeeper.VotePeriod(ctx))
 
-	val1ExpectedRewardFactor := fmt.Sprintf("%f", 1-(math.Log(float64(missCounters[0].MissCounter-missCounters[0].MissCounter+1))/math.Log(float64(len(voteTargets)-int(missCounters[0].MissCounter)+1))))
-	val2ExpectedRewardFactor := fmt.Sprintf("%f", 1-(math.Log(float64(missCounters[1].MissCounter-missCounters[0].MissCounter+1))/math.Log(float64(len(voteTargets)-int(missCounters[0].MissCounter)+1))))
+	val1ExpectedRewardFactor := fmt.Sprintf("%f", 1-(math.Log(float64(missCounters[0].MissCounter-missCounters[0].MissCounter+1))/
+		math.Log(float64(maximumMissCounts-(missCounters[0].MissCounter)+1))))
+	val2ExpectedRewardFactor := fmt.Sprintf("%f", 1-(math.Log(float64(missCounters[1].MissCounter-missCounters[0].MissCounter+1))/
+		math.Log(float64(maximumMissCounts-(missCounters[0].MissCounter)+1))))
 
 	votePeriodsPerWindow := sdk.NewDec((int64)(app.OracleKeeper.RewardDistributionWindow(ctx))).
 		QuoInt64((int64)(app.OracleKeeper.VotePeriod(ctx))).


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

- Found a bug when calculating reward factor where the maximum misscounters being used was the maximum amount of misses possible in a vote period rather than a slash window. This PR fixes it.
- Updated vote threshold enforcing to calculate denom power ratio with `sdk.NewDecWithPrec()`
closes: #66 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
