### PR TITLE
feat: Output docker logs on e2e failure

### DIFF
--- a/tests/e2e/orchestrator/orchestrator.go
+++ b/tests/e2e/orchestrator/orchestrator.go
@@ -395,7 +395,7 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 
 	isHealthy := false
 	for i := 0; i < 20; i++ {
-		isHealthy := checkHealth()
+		isHealthy = checkHealth()
 		if isHealthy {
 			break
 		}
@@ -414,7 +414,6 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 		if err != nil {
 			t.Log("Error retrieving price feeder logs", err)
 		}
-
 		t.Fatal("price-feeder not healthy")
 	}
 

--- a/tests/e2e/orchestrator/orchestrator.go
+++ b/tests/e2e/orchestrator/orchestrator.go
@@ -355,7 +355,7 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 				fmt.Sprintf("RPC_GRPC_ENDPOINT=%s", grpcEndpoint),
 				fmt.Sprintf("RPC_TMRPC_ENDPOINT=%s", tmrpcEndpoint),
 			},
-			Cmd: []string{"--skip-provider-check", "--bad-flag"},
+			Cmd: []string{"--skip-provider-check"},
 		},
 		noRestart,
 	)
@@ -403,7 +403,7 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 	}
 
 	if !isHealthy {
-		o.dkrPool.Client.Logs(docker.LogsOptions{
+		err := o.dkrPool.Client.Logs(docker.LogsOptions{
 			Container:    o.priceFeederResource.Container.ID,
 			OutputStream: os.Stdout,
 			ErrorStream:  os.Stderr,
@@ -411,6 +411,9 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 			Stderr:       true,
 			Tail:         "false",
 		})
+		if err != nil {
+			t.Log("Error retrieving price feeder logs", err)
+		}
 
 		t.Fatal("price-feeder not healthy")
 	}

--- a/tests/e2e/orchestrator/orchestrator.go
+++ b/tests/e2e/orchestrator/orchestrator.go
@@ -42,7 +42,7 @@ const (
 
 	priceFeederContainerRepo  = "ghcr.io/ojo-network/price-feeder-ojo"
 	priceFeederServerPort     = "7171/tcp"
-	priceFeederMaxStartupTime = 20 //seconds
+	priceFeederMaxStartupTime = 20 // seconds
 
 	initBalanceStr = "510000000000" + appparams.BondDenom
 )

--- a/tests/e2e/orchestrator/orchestrator.go
+++ b/tests/e2e/orchestrator/orchestrator.go
@@ -34,13 +34,15 @@ import (
 )
 
 const (
-	ojoContainerRepo = "ojo"
-	ojoP2pPort       = "26656"
-	ojoTmrpcPort     = "26657"
-	ojoGrpcPort      = "9090"
+	ojoContainerRepo  = "ojo"
+	ojoP2pPort        = "26656"
+	ojoTmrpcPort      = "26657"
+	ojoGrpcPort       = "9090"
+	ojoMaxStartupTime = 40 // seconds
 
-	priceFeederContainerRepo = "ghcr.io/ojo-network/price-feeder-ojo"
-	priceFeederServerPort    = "7171/tcp"
+	priceFeederContainerRepo  = "ghcr.io/ojo-network/price-feeder-ojo"
+	priceFeederServerPort     = "7171/tcp"
+	priceFeederMaxStartupTime = 20 //seconds
 
 	initBalanceStr = "510000000000" + appparams.BondDenom
 )
@@ -309,7 +311,7 @@ func (o *Orchestrator) runValidators(t *testing.T) {
 	}
 
 	isHealthy := false
-	for i := 0; i < 40; i++ {
+	for i := 0; i < ojoMaxStartupTime; i++ {
 		isHealthy = checkHealth()
 		if isHealthy {
 			break
@@ -406,7 +408,7 @@ func (o *Orchestrator) runPriceFeeder(t *testing.T) {
 	}
 
 	isHealthy := false
-	for i := 0; i < 20; i++ {
+	for i := 0; i < priceFeederMaxStartupTime; i++ {
 		isHealthy = checkHealth()
 		if isHealthy {
 			break


### PR DESCRIPTION
When the Ojo nodes or price-feeder fail to start in the e2e tests it is hard to figure out why when it is running in CI. When running them locally you can just inspect the logs of the problematic docker container.

- Output logs of docker container when Ojo nodes fail to start producing blocks
- Output logs of price-feeder when the health check never returns successful