### PR TITLE
fix: drop false assets instead of erroring

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -59,6 +59,15 @@ func CalcPrices(ctx sdk.Context, params types.Params, k keeper.Keeper) error {
 
 	// Iterate through ballots and update exchange rates; drop if not enough votes have been achieved.
 	for _, ballotDenom := range ballotDenomSlice {
+		// Increment Mandatory Win count if Denom in Mandatory list
+		incrementWin := params.MandatoryList.Contains(ballotDenom.Denom)
+
+		// If the asset is not in the mandatory or accept list, continue
+		if !incrementWin && !params.AcceptList.Contains(ballotDenom.Denom) {
+			ctx.Logger().Info("Unsupported denom, dropping ballot", "denom", ballotDenom)
+			continue
+		}
+
 		// Calculate the portion of votes received as an integer, scaled up using the
 		// same multiplier as the `threshold` computed above
 		support := ballotDenom.Ballot.Power() * types.MaxVoteThresholdMultiplier / totalBondedPower
@@ -66,9 +75,6 @@ func CalcPrices(ctx sdk.Context, params types.Params, k keeper.Keeper) error {
 			ctx.Logger().Info("Ballot voting power is under vote threshold, dropping ballot", "denom", ballotDenom)
 			continue
 		}
-
-		// Increment Mandatory Win count if Denom in Mandatory list
-		incrementWin := params.MandatoryList.Contains(ballotDenom.Denom)
 
 		// Get the current denom's reward band
 		rewardBand, err := params.RewardBands.GetBandFromDenom(ballotDenom.Denom)

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -140,6 +140,15 @@ func (s *IntegrationTestSuite) TestEndBlockerVoteThreshold() {
 		})
 	}
 
+	// add junk coin and ensure ballot still is counted
+	junkCoin := sdk.DecCoin{
+		Denom:  "JUNK",
+		Amount: sdk.MustNewDecFromStr("0.05"),
+	}
+	val1DecCoins = append(val1DecCoins, junkCoin)
+	val2DecCoins = append(val2DecCoins, junkCoin)
+	val3DecCoins = append(val3DecCoins, junkCoin)
+
 	h := uint64(ctx.BlockHeight())
 	val1PreVotes, val1Votes := createVotes("hash1", valAddr1, val1DecCoins, h)
 	val2PreVotes, val2Votes := createVotes("hash2", valAddr2, val2DecCoins, h)
@@ -155,7 +164,8 @@ func (s *IntegrationTestSuite) TestEndBlockerVoteThreshold() {
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr1, val1Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr2, val2Votes)
 	app.OracleKeeper.SetAggregateExchangeRateVote(ctx, valAddr3, val3Votes)
-	oracle.EndBlocker(ctx, app.OracleKeeper)
+	err := oracle.EndBlocker(ctx, app.OracleKeeper)
+	s.Require().NoError(err)
 
 	for _, denom := range app.OracleKeeper.AcceptList(ctx) {
 		rate, err := app.OracleKeeper.GetExchangeRate(ctx, denom.SymbolDenom)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Updates the endblocker to drop false assets instead of erroring out in the endblocker

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
