### PR TITLE
fix: potential wincount calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [182](https://github.com/ojo-network/ojo/pull/182) Set standard for oracle parameter symbols
 
+### Fixes
+
+- [197](https://github.com/ojo-network/ojo/pull/197) Fix potential win count calculations.
+
 ## [v0.1.3](https://github.com/ojo-network/ojo/releases/tag/v0.1.3) - 2023-05-09
 
 ### Features

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -61,7 +61,7 @@ func (k Keeper) PossibleWinsPerSlashWindow(ctx sdk.Context) int64 {
 	votePeriod := int64(k.VotePeriod(ctx))
 
 	votePeriodsPerWindow := sdk.NewDec(slashWindow).QuoInt64(votePeriod).TruncateInt64()
-	numberOfAssets := int64(len(k.GetParams(ctx).AcceptList))
+	numberOfAssets := int64(len(k.GetParams(ctx).MandatoryList))
 
 	return (votePeriodsPerWindow * numberOfAssets)
 }

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -105,7 +105,7 @@ func (s *IntegrationTestSuite) TestPossibleWinsPerSlashWindow() {
 			name:                       "no denoms in accept list",
 			votePeriod:                 5,
 			slashWindow:                15,
-			acceptmandatoryListList:    types.DenomList{},
+			mandatoryList:              types.DenomList{},
 			possibleWinsPerSlashWindow: 0,
 		},
 		{

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -91,28 +91,28 @@ func (s *IntegrationTestSuite) TestPossibleWinsPerSlashWindow() {
 		name                       string
 		votePeriod                 uint64
 		slashWindow                uint64
-		acceptList                 types.DenomList
+		mandatoryList              types.DenomList
 		possibleWinsPerSlashWindow int64
 	}{
 		{
 			name:                       "multiple denoms in accept list",
 			votePeriod:                 5,
 			slashWindow:                15,
-			acceptList:                 types.DenomList{atomDenom, umeeDenom},
+			mandatoryList:              types.DenomList{atomDenom, umeeDenom},
 			possibleWinsPerSlashWindow: 6,
 		},
 		{
 			name:                       "no denoms in accept list",
 			votePeriod:                 5,
 			slashWindow:                15,
-			acceptList:                 types.DenomList{},
+			acceptmandatoryListList:    types.DenomList{},
 			possibleWinsPerSlashWindow: 0,
 		},
 		{
 			name:                       "single denom in accept list",
 			votePeriod:                 2,
 			slashWindow:                10,
-			acceptList:                 types.DenomList{atomDenom},
+			mandatoryList:              types.DenomList{atomDenom},
 			possibleWinsPerSlashWindow: 5,
 		},
 	}
@@ -122,7 +122,7 @@ func (s *IntegrationTestSuite) TestPossibleWinsPerSlashWindow() {
 			params := types.DefaultParams()
 			params.VotePeriod = tc.votePeriod
 			params.SlashWindow = tc.slashWindow
-			params.AcceptList = tc.acceptList
+			params.MandatoryList = tc.mandatoryList
 			s.app.OracleKeeper.SetParams(s.ctx, params)
 			actual := s.app.OracleKeeper.PossibleWinsPerSlashWindow(s.ctx)
 			s.Require().Equal(tc.possibleWinsPerSlashWindow, actual)

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -95,21 +95,21 @@ func (s *IntegrationTestSuite) TestPossibleWinsPerSlashWindow() {
 		possibleWinsPerSlashWindow int64
 	}{
 		{
-			name:                       "multiple denoms in accept list",
+			name:                       "multiple denoms in mandatory list",
 			votePeriod:                 5,
 			slashWindow:                15,
 			mandatoryList:              types.DenomList{atomDenom, umeeDenom},
 			possibleWinsPerSlashWindow: 6,
 		},
 		{
-			name:                       "no denoms in accept list",
+			name:                       "no denoms in mandatory list",
 			votePeriod:                 5,
 			slashWindow:                15,
 			mandatoryList:              types.DenomList{},
 			possibleWinsPerSlashWindow: 0,
 		},
 		{
-			name:                       "single denom in accept list",
+			name:                       "single denom in mandatory list",
 			votePeriod:                 2,
 			slashWindow:                10,
 			mandatoryList:              types.DenomList{atomDenom},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Fixes potential wincount calculation to be based on the MandatoryList, not the AcceptList.

This causes issues when the Acceptlist has a different length than the Mandatorylist

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
