### PR TITLE
fix: store validator reward set via single key

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -114,13 +114,7 @@ func CalcPrices(ctx sdk.Context, params types.Params, k keeper.Keeper) error {
 	}
 
 	// Get the validators which can earn rewards in this Slash Window.
-	validatorRewardSet := types.ValidatorRewardSet{
-		ValidatorSet: []string{},
-	}
-	k.CurrentValidatorRewardSet(ctx, func(valRewardSet types.ValidatorRewardSet) bool {
-		validatorRewardSet = valRewardSet
-		return false
-	})
+	validatorRewardSet := k.GetValidatorRewardSet(ctx)
 
 	// update miss counting & slashing
 	voteTargetsLen := len(params.MandatoryList)

--- a/x/oracle/keeper/grpc_query.go
+++ b/x/oracle/keeper/grpc_query.go
@@ -320,11 +320,7 @@ func (q querier) ValidatorRewardSet(
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	validatorRewardSet := types.ValidatorRewardSet{}
-	q.CurrentValidatorRewardSet(ctx, func(valSet types.ValidatorRewardSet) bool {
-		validatorRewardSet = valSet
-		return false
-	})
+	validatorRewardSet := q.GetValidatorRewardSet(ctx)
 
 	return &types.QueryValidatorRewardSetResponse{
 		Validators: validatorRewardSet,

--- a/x/oracle/types/keys.go
+++ b/x/oracle/types/keys.go
@@ -83,8 +83,8 @@ func KeyHistoricPrice(denom string, blockNum uint64) (key []byte) {
 }
 
 // KeyValidatorRewardSet - stored by *block*
-func KeyValidatorRewardSet(blockNum uint64) (key []byte) {
-	return util.ConcatBytes(0, KeyPrefixValidatorRewardSet, util.UintWithNullPrefix(blockNum))
+func KeyValidatorRewardSet() (key []byte) {
+	return util.ConcatBytes(0, KeyPrefixValidatorRewardSet)
 }
 
 // ParseDenomAndBlockFromKey returns the denom and block contained in the *key*


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

The validator reward set was being stored via block, but we only need one instance of this at any given time 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
