### PR TITLE
fix: remove endblocker metrics to avoid panic

### DIFF
--- a/x/oracle/abci.go
+++ b/x/oracle/abci.go
@@ -33,10 +33,7 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) error {
 	if k.IsPeriodLastBlock(ctx, params.SlashWindow) {
 		k.SlashAndResetMissCounters(ctx)
 	}
-
 	k.PruneAllPrices(ctx)
-	go k.RecordEndBlockMetrics(ctx)
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This error is causing node 0 to restart "fatal error: concurrent map read and map write". Full Error log: https://gist.github.com/zarazan/d2d3e91556e202a0ba75d164595181d4

I believe it is the context being passed to RecordEndBlockMetrics that is causing the error.

Short term: we are not using these metrics yet. Let's remove them.

closes: #215 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
