### PR TITLE
ci: changed tidy go version in goreleaser to 1.20

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ env:
 
 before:
   hooks:
-    - go mod tidy -compat=1.19
+    - go mod tidy -compat=1.20
 
 builds:
   - main: ./cmd/ojod


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Bumped go version defined for tidy in goreleaser to be synced with go.mod version

Fixing:
`  ⨯ release failed after 0s                  error=hook failed: go mod tidy -compat=1.19: exit status 1; output: go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19`

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] added appropriate labels to the PR
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
