### PR TITLE
chore: revert price-feeder e2e image

### DIFF
--- a/tests/e2e/orchestrator/orchestrator.go
+++ b/tests/e2e/orchestrator/orchestrator.go
@@ -45,7 +45,7 @@ const (
 	ojoMaxStartupTime = 40 // seconds
 
 	// TODO: update original pf instance with sdk 0.47
-	priceFeederContainerRepo  = "ghcr.io/ojo-network/price-feeder-ojo-47"
+	priceFeederContainerRepo  = "ghcr.io/ojo-network/price-feeder-ojo"
 	priceFeederServerPort     = "7171/tcp"
 	priceFeederMaxStartupTime = 20 // seconds
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

Change the price-feeder docker image in the e2e tests back to the auto updated one now that the 0.47 changes are megred.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
