### PR TITLE
fix: payment trigger percentage & 0.5.1 update

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -359,7 +359,7 @@ func (app *App) registerUpgrade0_5_0(upgradeInfo upgradetypes.Plan) {
 	})
 }
 
-func (app *App) registerUpgrade0_5_1(upgradeInfo upgradetypes.Plan) {
+func (app *App) registerUpgrade0_5_1(_ upgradetypes.Plan) {
 	const planName = "v0.5.1"
 	app.UpgradeKeeper.SetUpgradeHandler(planName,
 		func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -49,6 +49,7 @@ func (app App) RegisterUpgradeHandlers() {
 	app.registerUpgrade0_4_0(upgradeInfo)
 	app.registerUpgrade0_4_1(upgradeInfo)
 	app.registerUpgrade0_5_0(upgradeInfo)
+	app.registerUpgrade0_5_1(upgradeInfo)
 }
 
 // performs upgrade from v0.1.3 to v0.1.4
@@ -68,7 +69,7 @@ func (app *App) registerUpgrade0_1_4(_ upgradetypes.Plan) {
 	)
 }
 
-//nolint: all
+// nolint: all
 func (app *App) registerUpgrade0_2_0(upgradeInfo upgradetypes.Plan) {
 	const planName = "v0.2.0"
 
@@ -356,6 +357,21 @@ func (app *App) registerUpgrade0_5_0(upgradeInfo upgradetypes.Plan) {
 			gasestimatetypes.ModuleName,
 		},
 	})
+}
+
+func (app *App) registerUpgrade0_5_1(upgradeInfo upgradetypes.Plan) {
+	const planName = "v0.5.1"
+	app.UpgradeKeeper.SetUpgradeHandler(planName,
+		func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			sdkCtx.Logger().Info("Upgrade handler execution", "name", planName)
+
+			params := app.GasEstimateKeeper.GetParams(sdkCtx)
+			params.GasAdjustment = "0.35"
+			app.GasEstimateKeeper.SetParams(sdkCtx, params)
+			return app.mm.RunMigrations(ctx, app.configurator, fromVM)
+		},
+	)
 }
 
 // helper function to check if the store loader should be upgraded

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -69,7 +69,7 @@ func (app *App) registerUpgrade0_1_4(_ upgradetypes.Plan) {
 	)
 }
 
-// nolint: all
+//nolint: all
 func (app *App) registerUpgrade0_2_0(upgradeInfo upgradetypes.Plan) {
 	const planName = "v0.2.0"
 

--- a/x/gmp/types/payment.go
+++ b/x/gmp/types/payment.go
@@ -6,6 +6,10 @@ import (
 )
 
 func (p Payment) TriggerUpdate(rate math.LegacyDec, ctx sdk.Context) bool {
-	return p.LastPrice.Sub(rate).Abs().GT(p.Deviation) ||
+	// Calculate the percentage difference
+	priceDiff := p.LastPrice.Sub(rate).Abs()
+	percentageDiff := priceDiff.Quo(p.LastPrice).MulInt64(100)
+
+	return percentageDiff.GT(p.Deviation) ||
 		p.LastBlock < ctx.BlockHeight()-p.Heartbeat
 }

--- a/x/gmp/types/payments_test.go
+++ b/x/gmp/types/payments_test.go
@@ -52,6 +52,19 @@ func TestPayment_TriggerUpdate(t *testing.T) {
 			ctx:  sdk.Context{}.WithBlockHeight(102),
 			want: true,
 		},
+
+		{
+			name: "should not trigger update - deviation within threshol",
+			payment: Payment{
+				LastPrice: math.LegacyMustNewDecFromStr("200"),
+				Deviation: math.LegacyMustNewDecFromStr("1"),
+				Heartbeat: 100,
+				LastBlock: 100,
+			},
+			rate: math.LegacyMustNewDecFromStr("202"),
+			ctx:  sdk.Context{}.WithBlockHeight(101),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

* The trigger to process a payment had a bug where it would trigger if the "whole number" of the deviation of the payment had changed. E.g, if the existing price is $200, and the new price is $201, and deviation is 1, it would have triggered.
* Also adds the 0.5.1 upgrade
* + updates the gasestimate module's gas adjustment parameter to 0.35